### PR TITLE
refactor: Assure test isolation with BATS_TEST_TMPDIR

### DIFF
--- a/test/mock_create.bats
+++ b/test/mock_create.bats
@@ -4,14 +4,16 @@ set -euo pipefail
 
 load ../src/bats-mock
 
-teardown() {
-  rm "${BATS_TMPDIR}/bats-mock.$$."*
-}
-
 @test 'mock_create creates a program' {
   run mock_create
   [[ "${status}" -eq 0 ]]
   [[ -x "${output}" ]]
+}
+
+@test 'mock_create creates a program in BATS_TEST_TMPDIR' {
+  run mock_create
+  [[ "${status}" -eq 0 ]]
+  [[ "$(dirname "${output}")" = "${BATS_TEST_TMPDIR}" ]]
 }
 
 @test 'mock_create names the program uniquely' {
@@ -23,8 +25,16 @@ teardown() {
   [[ "${output}" != "${mock}" ]]
 }
 
-@test 'mock_create creates a program in BATS_TMPDIR' {
+@test 'mock_create program names are not affected by deletion' {
+  mock_0=$(mock_create)
   run mock_create
   [[ "${status}" -eq 0 ]]
-  [[ "$(dirname "${output}")" = "${BATS_TMPDIR}" ]]
+  mock_1="${output}"
+  # Delete first mock to check if the names are not reused
+  rm "${mock_0}"
+  run mock_create
+  [[ "${status}" -eq 0 ]]
+  mock_2="${output}"
+
+  [[ "${mock_1}" != "${mock_2}" ]]
 }


### PR DESCRIPTION
Instead of using a shared temporary directory for mocks in BATS tests, leverage BATS_TEST_TMPDIR to create isolated mock directories for each test case.

This commit fixes an edge case where tests deleting mocks could potentially create name collisions.

Closes: #9