### PR TITLE
feat: Add support for mocking specific commands

### DIFF
--- a/test/mock_get_call_args.bats
+++ b/test/mock_get_call_args.bats
@@ -65,3 +65,12 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ "${output}" = '-n -e echo params' ]]
 }
+
+@test 'mock_get_call_args with mocked command' {
+  # shellcheck disable=SC2154
+  "${cmd}" one
+  "${cmd}" two
+  run mock_get_call_args "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = 'two' ]]
+}

--- a/test/mock_get_call_env.bats
+++ b/test/mock_get_call_env.bats
@@ -80,3 +80,12 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ -z "${output}" ]]
 }
+
+@test 'mock_get_call_env with mocked command' {
+  # shellcheck disable=SC2154
+  VAR='value 1' "${cmd}"
+  VAR='value 2' "${cmd}"
+  run mock_get_call_env "${cmd}" 'VAR'
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = 'value 2' ]]
+}

--- a/test/mock_get_call_num.bats
+++ b/test/mock_get_call_num.bats
@@ -22,3 +22,11 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ "${output}" -eq 2 ]]
 }
+
+@test 'mock_get_call_num with mocked command' {
+  # shellcheck disable=SC2154
+  "${cmd}"
+  run mock_get_call_num "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" -eq 1 ]]
+}

--- a/test/mock_get_call_user.bats
+++ b/test/mock_get_call_user.bats
@@ -57,3 +57,11 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ "${output}" = 'dan' ]]
 }
+
+@test 'mock_get_call_user with mocked command' {
+  # shellcheck disable=SC2154
+  _USER='alice' "${cmd}"
+  run mock_get_call_user "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = 'alice' ]]
+}

--- a/test/mock_set_output.bats
+++ b/test/mock_set_output.bats
@@ -59,3 +59,10 @@ load mock_test_suite
   run "${mock}"
   [[ -z "${output}" ]]
 }
+
+@test 'mock_set_output with mocked command' {
+  # shellcheck disable=SC2154
+  mock_set_output "${cmd}" 'output 1'
+  run "${cmd}"
+  [[ "${output}" = 'output 1' ]]
+}

--- a/test/mock_set_side_effect.bats
+++ b/test/mock_set_side_effect.bats
@@ -52,3 +52,10 @@ load mock_test_suite
   run "${mock}"
   [[ -e "${mock}.side_effect_5" && -e "${mock}.side_effect_6" ]]
 }
+
+@test 'mock_set_side_effect with mocked command' {
+  # shellcheck disable=SC2154
+  mock_set_side_effect "${cmd}" "touch ${cmd}.side_effect_1"
+  run "${cmd}"
+  [[ -e "${cmd}.side_effect_1" ]]
+}

--- a/test/mock_set_status.bats
+++ b/test/mock_set_status.bats
@@ -38,3 +38,9 @@ load mock_test_suite
   run "${mock}"
   [[ "${status}" -eq 0 ]]
 }
+
+@test 'mock_set_status with mocked command' {
+  # shellcheck disable=SC2154
+  mock_set_status "${cmd}" 127
+  run -127 "${cmd}"
+}

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -8,4 +8,5 @@ load '../load'
 setup() {
   bats_require_minimum_version 1.5.0
   mock="$(mock_create)"
+  cmd="$(mock_create example)"
 }


### PR DESCRIPTION
Extend the `mock_create` function to optionally accept a command name, enabling users to mock calls to specific commands. This enhancement maintains backward compatibility with the existing API while providing a more flexible and realistic mocking workflow.

The mocked command is created as symbolic link in `BATS_TEST_TMPDIR`.

Closes: #10