### PR TITLE
refactor: Comply to BATS coding conventions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
-Max Hofer <mh182@chello.at> (https://github.com/mh182)
-Sergey Konoplev <gray.ru@gmail.com> (https://github.com/grayhemp)
+Marek Brieger (<https://github.com/polmabri>)
+Max Hofer <mh182@chello.at> (<https://github.com/mh182>)
+Sergey Konoplev <gray.ru@gmail.com> (<https://github.com/grayhemp>)

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -294,7 +294,7 @@ mock_set_property() {
 mock_default_n() {
   local mock="${1?'Mock must be specified'}"
   local call_num
-  read -r call_num <"${mock}.call_num"
+  IFS= read -r call_num <"${mock}.call_num" || true
   local n="${2:-${call_num}}"
 
   if [[ "${n}" -eq 0 ]]; then

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 #
 # A Bats helper library providing mocking functionality
+#
+# Written in 2018-2021 by Sergey Konoplev <gray dot ru at gmail dot com>,
+# updated in 2025-2026 by Max Hofer <mh182 at chello dot at>.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# For more information, please refer to <http://unlicense.org>
+#
 
-# Assure test isolation by using BATS_TEST_TMPDIR introduced with bats 1.4.0
+# Ensure test isolation by using BATS_TEST_TMPDIR introduced with bats 1.4.0
 bats_require_minimum_version '1.4.0'
 
 # Creates a mock program
@@ -12,7 +25,7 @@ bats_require_minimum_version '1.4.0'
 #   1: Command to mock, optional
 # Returns:
 #   1: If the mock command already exists
-#   1: If the command provided with an absoluth path already exists
+#   1: If the command provided with an absolute path already exists
 # Outputs:
 #   STDOUT: Path to the mock
 #   STDERR: Corresponding error message
@@ -35,14 +48,14 @@ mock_create() {
 
   # If a command name is provided, create a symbolic link to the mock
   if [[ -n "${cmd}" ]]; then
-    # Don't create the mock if we cant create the link
-    cmd=$(mock_set_command "${mock}" "${cmd}") || exit $?
+    # Don't create the mock if we can't create the link
+    cmd=$(mock_set_command "${mock}" "${cmd}") || return $?
   fi
 
-  echo -n 0 >"${mock}.call_num"
-  echo -n 0 >"${mock}.status"
-  echo -n '' >"${mock}.output"
-  echo -n '' >"${mock}.side_effect"
+  printf '%s' 0 >"${mock}.call_num"
+  printf '%s' 0 >"${mock}.status"
+  printf '%s' '' >"${mock}.output"
+  printf '%s' '' >"${mock}.side_effect"
 
   cat <<EOF >"${mock}"
 #!/usr/bin/env bash
@@ -51,7 +64,8 @@ set -e
 
 mock="${mock}"
 
-call_num="\$(( \$(cat \${mock}.call_num) + 1 ))"
+IFS= read -r prev_call_num < "\${mock}.call_num" || true
+call_num="\$(( prev_call_num + 1 ))"
 echo "\${call_num}" > "\${mock}.call_num"
 
 echo "\${_USER:-\$(id -un)}" > "\${mock}.user.\${call_num}"
@@ -75,10 +89,11 @@ else
 fi
 
 if [[ -e "\${mock}.status.\${call_num}" ]]; then
-  exit "\$(cat \${mock}.status.\${call_num})"
+  IFS= read -r status_value < "\${mock}.status.\${call_num}" || true
 else
-  exit "\$(cat \${mock}.status)"
+  IFS= read -r status_value < "\${mock}.status" || true
 fi
+exit "\${status_value}"
 EOF
   chmod +x "${mock}"
 
@@ -89,7 +104,7 @@ EOF
   fi
 }
 
-# Creates a symbolic link with given name to a mock program
+# Creates a symbolic link with the given name to a mock program
 #
 # This method is not meant to be called directly. Use mock_create instead.
 #
@@ -98,7 +113,7 @@ EOF
 #   2: Command name
 # Returns:
 #   1: If the mock command already exists
-#   1: If the command provided with an absoluth path already exists
+#   1: If the command provided with an absolute path already exists
 # Outputs:
 #   STDOUT: Path to the mocked command
 #   STDERR: Corresponding error message
@@ -108,22 +123,22 @@ mock_set_command() {
   local link_name="${mock%/*}/${cmd}"
 
   if [[ "${cmd}" = /* ]]; then
-    # Command with abolute path
+    # Command with absolute path
     if [[ -e "${cmd}" ]]; then
-      echo "mock_create: failed to create command '${cmd}': command exists" >&2
-      exit 1
+      printf "mock_create: failed to create command '%s': command exists\n" "${cmd}" >&2
+      return 1
     fi
     link_name=${cmd}
-    mkdir -p "$(dirname "${link_name}")"
+    mkdir -p "${link_name%/*}"
   elif [[ -e "${link_name}" ]]; then
     # Link already exists: either created by mock_create or mock_bin_dir
     if [[ $(readlink "${link_name}") =~ ${BATS_TEST_TMPDIR} ]]; then
-      # Link pointing to  mock (created by mock_create)
-      echo "mock_create: failed to create command '${cmd}': command exists" >&2
-      exit 1
+      # Link pointing to a mock (created by mock_create)
+      printf "mock_create: failed to create command '%s': command exists\n" "${cmd}" >&2
+      return 1
     else
       # Link pointing to outside $BATS_TEST_TMPDIR (created by mock_bin_dir).
-      # We can savely delete it, to create a new one.
+      # We can safely delete it to create a new one.
       rm "${link_name}"
     fi
   fi
@@ -196,7 +211,7 @@ mock_get_call_user() {
   mock=$(readlink -f "${mock}")
 
   local n
-  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || return "$?"
 
   cat "${mock}.user.${n}"
 }
@@ -213,7 +228,7 @@ mock_get_call_args() {
   mock=$(readlink -f "${mock}")
 
   local n
-  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || return "$?"
 
   cat "${mock}.args.${n}"
 }
@@ -232,7 +247,7 @@ mock_get_call_env() {
   mock=$(readlink -f "${mock}")
 
   local n
-  n="$(mock_default_n "${mock}" "${3-}")" || exit "$?"
+  n="$(mock_default_n "${mock}" "${3-}")" || return "$?"
 
   # shellcheck source=/dev/null
   source "${mock}.env.${n}"
@@ -261,9 +276,9 @@ mock_set_property() {
   mock=$(readlink -f "${mock}")
 
   if [[ -n "${n}" ]]; then
-    echo -e "${property_value}" >"${mock}.${property_name}.${n}"
+    printf "%b" "${property_value}" >"${mock}.${property_name}.${n}"
   else
-    echo -e "${property_value}" >"${mock}.${property_name}"
+    printf "%b" "${property_value}" >"${mock}.${property_name}"
   fi
 }
 
@@ -279,7 +294,7 @@ mock_set_property() {
 mock_default_n() {
   local mock="${1?'Mock must be specified'}"
   local call_num
-  call_num="$(cat "${mock}.call_num")"
+  read -r call_num <"${mock}.call_num"
   local n="${2:-${call_num}}"
 
   if [[ "${n}" -eq 0 ]]; then
@@ -287,8 +302,8 @@ mock_default_n() {
   fi
 
   if [[ "${n}" -gt "${call_num}" ]]; then
-    echo "$(basename "$0"): Mock must be called at least ${n} time(s)" >&2
-    exit 1
+    printf "%s: Mock must be called at least %s time(s)\n" "${0##*/}" "${n}" >&2
+    return 1
   fi
 
   echo "${n}"
@@ -307,7 +322,7 @@ path_prepend() {
 
   if [[ "${mock}" != /* ]]; then
     echo "Relative paths are not allowed"
-    exit 1
+    return 1
   fi
 
   if [[ -f "${mock}" ]]; then
@@ -315,7 +330,7 @@ path_prepend() {
     local mock_path="${mock%/*}"
   fi
 
-  # Putting the directory with the mocked comands at the beginning of the PATH
+  # Putting the directory with the mocked commands at the beginning of the PATH
   # so it gets picked up first
   if [[ :${path}: == *:${mock_path}:* ]]; then
     echo "${path}"
@@ -327,7 +342,7 @@ path_prepend() {
 # Returns $PATH without the provided path
 # Arguments:
 #   1: Path to be removed
-#   2: Path from which the 1st argument is removed. Defaults to $PATH if not provided.
+#   2: Path list from which the 1st argument is removed. Defaults to $PATH if not provided.
 # Outputs:
 #   STDOUT: a path without the path provided in ${1}
 path_rm() {
@@ -335,12 +350,13 @@ path_rm() {
   local path=${2:-${PATH}}
   if [[ "${path_or_cmd_to_remove}" != /* ]] && [[ "${path_or_cmd_to_remove}" == *"/"* ]]; then
     echo "Relative paths are not allowed"
-    exit 1
+    return 1
   fi
 
   if [[ "${path_or_cmd_to_remove}" == /* ]]; then
-    # Absolute path to a command or directory, remove the directory and exit
-    _remove_path "${path_or_cmd_to_remove}"
+    # Absolute path to a command or directory, remove the directory and return
+    _remove_path "${path_or_cmd_to_remove}" "${path}" path
+    echo "${path}"
     return
   fi
 
@@ -349,28 +365,30 @@ path_rm() {
   local path_to_cmd
 
   while path_to_cmd=$(PATH=${path} command -v "${path_or_cmd_to_remove}"); do
-    # We can resolved the command
+    # We can resolve the command
     # Use parameter expansion to get the folder portion of the command
     path_to_remove=${path_to_cmd%/*}
-    path=$(_remove_path "${path_to_remove}")
+    _remove_path "${path_to_remove}" "${path}" path
   done
   echo "${path}"
 }
 
 _remove_path() {
   local path_to_remove="${1?'Path to remove must be specified'}"
+  local input_path="${2?'Path list must be specified'}"
+  local output_var_name="${3?'Output variable name must be specified'}"
   # Wrap the path with colons to simplify removal
-  local path=":$path:"
+  local updated_path=":${input_path}:"
   # Replace single colons with double colons for easier string substitution
-  path=${path//":"/"::"}
+  updated_path=${updated_path//":"/"::"}
   # Remove the path
-  path=${path//":${path_to_remove}:"/}
+  updated_path=${updated_path//":${path_to_remove}:"/}
   # Restore single colons
-  path=${path//"::"/":"}
+  updated_path=${updated_path//"::"/":"}
   # Clean up leading/trailing colons
-  path=${path#:}
-  path=${path%:}
-  echo "${path}"
+  updated_path=${updated_path#:}
+  updated_path=${updated_path%:}
+  printf -v "${output_var_name}" '%s' "${updated_path}"
 }
 
 # Returns a path to directory populated with symbolic links to basic commands
@@ -396,14 +414,20 @@ mock_bin_dir() {
       split tail tee tempfile touch tr tty uname uniq unlink
       wc which xargs)
   fi
+
+  local c
+  local target
+  local error_msg
   for c in "${commands[@]}"; do
     if target=$(command -v "$c" 2>&1); then
       # Use 'command -p' to assure ln is found, since '/bin' or '/usr/bin' may be not in $PATH anymore.
       if ! error_msg=$(command -p ln -s "${target}" "${bin_dir}/${c}" 2>&1) && ${customized}; then
-        echo "${error_msg}" && exit 1
+        echo "${error_msg}"
+        return 1
       fi
     elif ${customized}; then
-      echo "$c: command not found" && exit 1
+      printf "%s: command not found" "$c"
+      return 1
     fi
   done
   echo "${bin_dir}"

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -129,7 +129,7 @@ mock_set_command() {
       return 1
     fi
     link_name=${cmd}
-    mkdir -p "${link_name%/*}"
+    mkdir -p "${link_name%/*}/"
   elif [[ -e "${link_name}" ]]; then
     # Link already exists: either created by mock_create or mock_bin_dir
     if [[ $(readlink "${link_name}") =~ ${BATS_TEST_TMPDIR} ]]; then

--- a/test/mock_get_call_args.bats
+++ b/test/mock_get_call_args.bats
@@ -5,7 +5,7 @@ load mock_test_suite
 @test 'mock_get_call_args requires mock to be specified' {
   run mock_get_call_args
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_get_call_args requires the mock to be called' {
@@ -26,7 +26,7 @@ load mock_test_suite
 @test 'mock_get_call_args requires the mock to be called 1 time' {
   run mock_get_call_args "${mock}" 1
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
 }
 
 @test 'mock_get_call_args requires the mock to be called 2 times' {

--- a/test/mock_get_call_env.bats
+++ b/test/mock_get_call_env.bats
@@ -5,14 +5,14 @@ load mock_test_suite
 @test 'mock_get_call_env requires mock to be specified' {
   run mock_get_call_env
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_get_call_env requires variable to be specified' {
   # shellcheck disable=SC2154
   run mock_get_call_env "${mock}"
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Variable name must be specified' ]]
+  [[ "${output}" =~ Variable\ name\ must\ be\ specified ]]
 }
 
 @test 'mock_get_call_env requires the mock to be called' {
@@ -32,7 +32,7 @@ load mock_test_suite
 @test 'mock_get_call_env requires the mock to be called 1 time' {
   run mock_get_call_env "${mock}" 'VAR' 1
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
 }
 
 @test 'mock_get_call_env requires the mock to be called 2 times' {
@@ -41,13 +41,13 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   run mock_get_call_env "${mock}" 'VAR' 2
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 2\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 2\ time\(s\) ]]
 }
 
 @test 'mock_get_call_env requires the mock to be called 3 times' {
   run mock_get_call_env "${mock}" 'VAR' 3
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 3\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 3\ time\(s\) ]]
 }
 
 @test 'mock_get_call_env outputs the n-th call variable' {

--- a/test/mock_get_call_num.bats
+++ b/test/mock_get_call_num.bats
@@ -5,7 +5,7 @@ load mock_test_suite
 @test 'mock_get_call_num requires mock to be specified' {
   run mock_get_call_num
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_get_call_num outputs the number of calls' {

--- a/test/mock_get_call_user.bats
+++ b/test/mock_get_call_user.bats
@@ -5,14 +5,14 @@ load mock_test_suite
 @test 'mock_get_call_user requires mock to be specified' {
   run mock_get_call_user
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_get_call_user requires the mock to be called' {
   # shellcheck disable=SC2154
   run mock_get_call_user "${mock}"
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
 }
 
 @test 'mock_get_call_user outputs the last call user if no n is specified' {
@@ -26,7 +26,7 @@ load mock_test_suite
 @test 'mock_get_call_user requires the mock to be called 1 time' {
   run mock_get_call_user "${mock}" 1
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 1\ time\(s\) ]]
 }
 
 @test 'mock_get_call_user requires the mock to be called 2 times' {
@@ -35,13 +35,13 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   run mock_get_call_user "${mock}" 2
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 2\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 2\ time\(s\) ]]
 }
 
 @test 'mock_get_call_user requires the mock to be called 3 times' {
   run mock_get_call_user "${mock}" 3
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ \Mock\ must\ be\ called\ at\ least\ 3\ time\(s\) ]]
+  [[ "${output}" =~ Mock\ must\ be\ called\ at\ least\ 3\ time\(s\) ]]
 }
 
 @test 'mock_get_call_user outputs the n-th call user' {

--- a/test/mock_set_output.bats
+++ b/test/mock_set_output.bats
@@ -5,14 +5,14 @@ load mock_test_suite
 @test 'mock_set_output requires mock to be specified' {
   run mock_set_output
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_set_output requires output to be specified' {
   # shellcheck disable=SC2154
   run mock_set_output "${mock}"
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Output must be specified' ]]
+  [[ "${output}" =~ Output\ must\ be\ specified ]]
 }
 
 @test 'mock_set_output no output is set by default' {

--- a/test/mock_set_side_effect.bats
+++ b/test/mock_set_side_effect.bats
@@ -5,14 +5,14 @@ load mock_test_suite
 @test 'mock_set_side_effect requires mock to be specified' {
   run mock_set_side_effect
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_set_side_effect requires side_effect to be specified' {
   # shellcheck disable=SC2154
   run mock_set_side_effect "${mock}"
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Side effect must be specified' ]]
+  [[ "${output}" =~ Side\ effect\ must\ be\ specified ]]
 }
 
 @test 'mock_set_side_effect sets a side_effect 1' {

--- a/test/mock_set_status.bats
+++ b/test/mock_set_status.bats
@@ -5,14 +5,14 @@ load mock_test_suite
 @test 'mock_set_status requires mock to be specified' {
   run mock_set_status
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'mock_set_status requires status to be specified' {
   # shellcheck disable=SC2154
   run mock_set_status "${mock}"
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Status must be specified' ]]
+  [[ "${output}" =~ Status\ must\ be\ specified ]]
 }
 
 @test 'mock_set_status 0 status is set by default' {

--- a/test/path_prepend.bats
+++ b/test/path_prepend.bats
@@ -5,7 +5,7 @@ load mock_test_suite
 @test 'path_prepend requires mock to be specified' {
   run path_prepend
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Mock must be specified' ]]
+  [[ "${output}" =~ Mock\ must\ be\ specified ]]
 }
 
 @test 'path_prepend returns PATH prefixed with the mock directory' {
@@ -39,5 +39,5 @@ load mock_test_suite
 @test "path_prepend doesn't accept relative paths" {
   run path_prepend 'relative/path' '/a/b:/c/d'
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Relative paths are not allowed' ]]
+  [[ "${output}" =~ Relative\ paths\ are\ not\ allowed ]]
 }

--- a/test/path_rm.bats
+++ b/test/path_rm.bats
@@ -5,7 +5,7 @@ load mock_test_suite
 @test 'path_rm requires a path or command to remove to be specified' {
   run path_rm
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Path or command to remove must be specified' ]]
+  [[ "${output}" =~ Path\ or\ command\ to\ remove\ must\ be\ specified ]]
 }
 
 @test 'path_rm removes directory from PATH' {
@@ -24,28 +24,28 @@ load mock_test_suite
   run path_rm "/a/b" "/a/b:/c/d:/e/f"
 
   [[ "${status}" -eq 0 ]]
-  [[ "${output}" =~ '/c/d:/e/f' ]]
+  [[ "${output}" =~ /c/d:/e/f ]]
 }
 
 @test 'path_rm removes directory from given path - path middle' {
   run path_rm "/c/d" "/a/b:/c/d:/e/f"
 
   [[ "${status}" -eq 0 ]]
-  [[ "${output}" =~ '/a/b:/e/f' ]]
+  [[ "${output}" =~ /a/b:/e/f ]]
 }
 
 @test 'path_rm removes directory from given path - path tail' {
   run path_rm "/e/f" "/a/b:/c/d:/e/f"
 
   [[ "${status}" -eq 0 ]]
-  [[ "${output}" =~ '/a/b:/c/d' ]]
+  [[ "${output}" =~ /a/b:/c/d ]]
 }
 
 @test 'path_rm returns path unchanged if it is not contained' {
   run path_rm "/a/x" "/c/d:/a/b:/e/f"
 
   [[ "${status}" -eq 0 ]]
-  [[ "${output}" =~ '/c/d:/a/b:/e/f' ]]
+  [[ "${output}" =~ /c/d:/a/b:/e/f ]]
 }
 
 @test "path_rm removes directories of given command so that command is no longer found" {
@@ -64,5 +64,5 @@ load mock_test_suite
   run path_rm "relative/path" "/a/b:/a/b/relative/path:/c/d"
 
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ 'Relative paths are not allowed' ]]
+  [[ "${output}" =~ Relative\ paths\ are\ not\ allowed ]]
 }


### PR DESCRIPTION
See https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md#coding-conventions

Apply coding conventions:
- Declare all variables in functions using `local`
- Use `return` instead of `exit`
- Use `printf` instead of `echo`
- Avoid unnecessary command substitutions
- Don't quote variables and strings appearing on the right side of the `=~` operator

Added copyright header and license information. 
Fixed typos in comments.