### PR TITLE
build: Add static analysis checks for Github actions

### DIFF
--- a/.github/workflows/debug-session.yml
+++ b/.github/workflows/debug-session.yml
@@ -20,13 +20,17 @@ jobs:
   debug:
     name: Debug on ${{ github.event.inputs.debug_os }}
     runs-on: ${{ github.event.inputs.debug_os }}
+    permissions:
+      contents: read
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 🐞 Setup interactive tmate session (detached)
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113   # v3.24
         with:
           detached: true
 

--- a/.github/workflows/devcontainer-image.yml
+++ b/.github/workflows/devcontainer-image.yml
@@ -10,7 +10,6 @@ name: Devcontainer Image
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   guard-version-sync:
@@ -20,9 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check if Containerfile and image-version are in sync
         run: |
@@ -58,12 +58,17 @@ jobs:
     name: Build devcontainer and validate
     runs-on: ubuntu-24.04
     needs: guard-version-sync
+    permissions:
+      contents: read
+      packages: write
     environment:
       name: container-publish
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read image version
         id: image-version
@@ -78,15 +83,19 @@ jobs:
       - name: Prepare image reference
         id: image-ref
         run: |
-          image_ref="ghcr.io/${GITHUB_REPOSITORY,,}-dev:${{ steps.image-version.outputs.image_version }}"
+          image_ref="ghcr.io/${GITHUB_REPOSITORY,,}-dev:${STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_VERSION}"
           echo "image_ref=${image_ref}" >> "${GITHUB_OUTPUT}"
+        env:
+          STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_VERSION: ${{ steps.image-version.outputs.image_version }}
 
       - name: Build image from devcontainer Containerfile
         run: |
           docker build \
-            -t "${{ steps.image-ref.outputs.image_ref }}" \
+            -t "${STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF}" \
             -f .devcontainer/Containerfile \
             .
+        env:
+          STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
 
       - name: Run build check in container
         run: |
@@ -94,8 +103,10 @@ jobs:
             -v "$PWD:/code" \
             -w /code \
             --entrypoint /bin/bash \
-            "${{ steps.image-ref.outputs.image_ref }}" \
+            "${STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF}" \
             ./build check
+        env:
+          STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
 
       - name: Run build test in container
         run: |
@@ -103,12 +114,14 @@ jobs:
             -v "$PWD:/code" \
             -w /code \
             --entrypoint /bin/bash \
-            "${{ steps.image-ref.outputs.image_ref }}" \
+            "${STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF}" \
             ./build test
+        env:
+          STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
 
       - name: Login to GHCR
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee   # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,7 +129,9 @@ jobs:
 
       - name: Push versioned image to GHCR
         if: github.event.pull_request.head.repo.full_name == github.repository
-        run: docker push "${{ steps.image-ref.outputs.image_ref }}"
+        run: docker push "${STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF}"
+        env:
+          STEPS_IMAGE_REF_OUTPUTS_IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
 
       - name: Explain skipped push for fork PR
         if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pull-requests: write
+  contents: read
   packages: read
 
 jobs:
@@ -22,10 +22,16 @@ jobs:
   lint:
     name: Formal Checks (Linux)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 🧮 Read image version
         id: image-version
@@ -38,14 +44,16 @@ jobs:
           echo "image_ref=ghcr.io/${GITHUB_REPOSITORY,,}-dev:${image_version}" >> "${GITHUB_OUTPUT}"
 
       - name: 🔐 Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee   # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📥 Pull development container image
-        run: docker pull "${{ steps.image-version.outputs.image_ref }}"
+        run: docker pull "${STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_REF}"
+        env:
+          STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_REF: ${{ steps.image-version.outputs.image_ref }}
 
       - name: 🔍 Run formal checks
         run: |
@@ -54,11 +62,13 @@ jobs:
             -v "$PWD:/code" \
             -w /code \
             --entrypoint /bin/bash \
-            "${{ steps.image-version.outputs.image_ref }}" \
+            "${STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_REF}" \
             ./build check
+        env:
+          STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_REF: ${{ steps.image-version.outputs.image_ref }}
 
       - name: Comment broken links in documentation
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0    # v3.0.4
         with:
           path: .lychee-out.md
 
@@ -69,8 +79,10 @@ jobs:
             -v "$PWD:/code" \
             -w /code \
             --entrypoint /bin/bash \
-            "${{ steps.image-version.outputs.image_ref }}" \
+            "${STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_REF}" \
             -lc 'bats --version && bats test --print-output-on-failure'
+        env:
+          STEPS_IMAGE_VERSION_OUTPUTS_IMAGE_REF: ${{ steps.image-version.outputs.image_ref }}
 
   # -------------------------------------------------------
   # Bats test suite across OS versions
@@ -87,7 +99,9 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 🧰 Install dependencies
         run: |
@@ -109,4 +123,4 @@ jobs:
           github.event_name == 'workflow_dispatch' &&
           github.event.inputs.debug_enabled == 'true' &&
           matrix.os == github.event.inputs.debug_os
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113   # v3.24

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,34 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+# docs https://docs.zizmor.sh/integrations/#github-actions
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  pull_request:
+    branches: ["**"]
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bats-mock
 
 [![Tests](https://github.com/mh182/bats-mock/actions/workflows/tests.yml/badge.svg)](https://github.com/mh182/bats-mock/actions/workflows/tests.yml)
+[![GitHub Actions Security Analysis with zizmor](https://github.com/mh182/bats-mock/actions/workflows/zizmor.yml/badge.svg)](https://github.com/mh182/bats-mock/actions/workflows/zizmor.yml)
 
 A [Bats][bats-core] helper library providing mocking functionality.
 


### PR DESCRIPTION
Use zizmor to check for common seecurity issues.

Adressed findings:
- overly broad permissions
- credential persistence through GitHub Actions artifacts
- code injection via template expansion
- unpinned action reference

Closes: #46